### PR TITLE
해시태그 메뉴 추가

### DIFF
--- a/src/main/resources/templates/header.th.xml
+++ b/src/main/resources/templates/header.th.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#home" th:href="@{/}" />
+    <attr sel="#hashtag" th:href="@{/articles/search-hashtag}" />
+</thlogic>


### PR DESCRIPTION
이전(#38)에 추가한 해시태그 메뉴를 보기 위한 메뉴를 메인 페이지에 추가

This closes #41 